### PR TITLE
postTask explainer cleanup

### DIFF
--- a/explainers/prioritized-post-task.md
+++ b/explainers/prioritized-post-task.md
@@ -153,8 +153,8 @@ APIs](#post-mvp-api-areas-of-exploration) to support these.
 
 2. **user-visible**: User-visible tasks are those that will be visible to the
    user, but either not immediately or do not block the user from interacting
-   with the page. These tasks represent either a different importance or
-   timescale as user-blocking tasks.
+   with the page. These tasks have either a different importance or
+   timescale than user-blocking tasks.
 
    **Note**: this is the default `postTask` priority if a priority is not
    specified.

--- a/explainers/prioritized-post-task.md
+++ b/explainers/prioritized-post-task.md
@@ -36,8 +36,8 @@ schedulers use an internal notion of priority to order execution of tasks they
 control, but this has limited meaning since they do not control all tasks on
 the page. Apps can consist of 1P, 1P library, 3P, and (one or more) framework
 script, all of which compete for the thread. At the same time, the browser has
-tasks to run on the main thread, such as async work (e.g. `fetch()` and
-IndexedDB tasks) and garbage collection.
+tasks to run on the thread, such as async work (e.g. `fetch()` and IndexedDB
+tasks) and garbage collection.
 
 ### Existing Priorities
 


### PR DESCRIPTION
In addition to some minor edits, the main changes are:
 
 * Add an explicit goals and non-goals section
 * Add metadata (author, issue tracker, spec)
 * Clean up introduction prose
 * Reorder and tweak post-MVP exploration
 * Mention API shape evolution
