### PR TITLE
Change TaskController constructor to take an optional dictionary

### DIFF
--- a/explainers/post-task-propagation.md
+++ b/explainers/post-task-propagation.md
@@ -36,7 +36,7 @@ function task1(signal) {
   // ... do more work ...
 }
 
-const controller = new TaskController('background');
+const controller = new TaskController({priority: 'background'});
 scheduler.postTask(task1, { signal }, signal);
 ```
 
@@ -66,7 +66,7 @@ function task1() {
   // ... do more work ...
 }
 
-const controller = new TaskController('background');
+const controller = new TaskController({priority: 'background'});
 scheduler.postTask(task1, { signal });
 ```
 
@@ -108,7 +108,7 @@ function task1() {
   // ... do more work ...
 }
 
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 scheduler.postTask(task1, { controller.signal });
 ```
 

--- a/explainers/prioritized-post-task.md
+++ b/explainers/prioritized-post-task.md
@@ -248,7 +248,7 @@ supports `AbortController` operations (`abort()`) and an additional
 with a `TaskController`:
 
 ```javascript
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 
 // |signal| is an instance of a TaskSignal, which has read-only properties for
 // the aborted state and current priority.
@@ -274,7 +274,7 @@ masse. For example, a `TaskSignal` can be passed to `fetch` and can be used to
 cancel pending postTask tasks and ongoing fetches.
 
 ```javascript
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 const signal = controller.signal;
 
 function doWork() {
@@ -313,7 +313,7 @@ to express priority and communicate priority change.
 Consider the following example:
 
 ```javascript
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 const signal = controller.signal;
 
 scheduler.postTask(() => {
@@ -342,7 +342,7 @@ verbose way to handle this use case, which involves listening for the parent
 signal's [`abort` event](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_event):
 
 ```javascript
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 const signal = controller.signal;
 
 scheduler.postTask(() => {
@@ -368,7 +368,7 @@ using either the `addEventListener` method or `onprioritychange` property of a
 property of the associated event.
 
 ```javascript
-const controller = new TaskController('user-blocking');
+const controller = new TaskController({priority: 'user-blocking'});
 const signal = controller.signal;
 
 // Method 1: using onprioritychange.

--- a/sample-code/controlling-scheduled-tasks.html
+++ b/sample-code/controlling-scheduled-tasks.html
@@ -16,7 +16,7 @@
         //
         // TaskController takes a single argument for the priority. Similar to postTask,
         // the priority is optional and defaults to 'user-visible'.
-        const headerController = new TaskController('background');
+        const headerController = new TaskController({priority: 'background'});
 
         // To link the TaskController to tasks, the TaskController's TaskSignal needs
         // to be provided to postTask.

--- a/sample-code/tasksignal-propagation.html
+++ b/sample-code/tasksignal-propagation.html
@@ -68,7 +68,7 @@
       controller.abort();
     }
 
-    let controller = new TaskController('user-visible');
+    let controller = new TaskController({priority: 'user-visible'});
     await scheduler.postTask(propagationEqualityAndPriorities, { signal: controller.signal });
 
     scheduler.postTask(() => propagationAbort(controller), { signal: controller.signal });

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -42,9 +42,13 @@ The `TaskController` Interface {#sec-task-controller}
 ---------------------
 
 <pre class='idl'>
+  dictionary TaskControllerInit {
+    TaskPriority priority = "user-visible";
+  };
+
   [Exposed=(Window,Worker)]
   interface TaskController : AbortController {
-    constructor(optional TaskPriority priority = "user-visible");
+    constructor(optional TaskControllerInit init = {});
 
     undefined setPriority(TaskPriority priority);
   };
@@ -54,11 +58,11 @@ Note: {{TaskController}}'s {{AbortController/signal}} getter, which is
 inherited from {{AbortController}}, returns a {{TaskSignal}} object.
 
 <dl class="domintro non-normative">
-  <dt><code>controller = new {{TaskController/TaskController()|TaskController}}( |priority| )</code>
+  <dt><code>controller = new {{TaskController/TaskController()|TaskController}}( |init| )</code>
   <dd>
     <p> Returns a new {{TaskController}} whose {{AbortController/signal}} is
     set to a newly created {{TaskSignal}} with its {{TaskSignal/priority}}
-    initialized to |priority|.
+    initialized to |init|'s {{TaskControllerInit/priority}}.
   </dd>
 
   <dt><code>controller . {{TaskController/setPriority()|setPriority}}( |priority| )</code>
@@ -70,11 +74,11 @@ inherited from {{AbortController}}, returns a {{TaskSignal}} object.
 </dl>
 
 <div algorithm>
-  The <dfn constructor for="TaskController" lt="TaskController()"><code>new TaskController(|priority|)</code></dfn>
+  The <dfn constructor for="TaskController" lt="TaskController()"><code>new TaskController(|init|)</code></dfn>
   constructor steps are:
 
   1. Let |signal| be a new {{TaskSignal}} object.
-  1. Set |signal|'s [=TaskSignal/priority=] to |priority|.
+  1. Set |signal|'s [=TaskSignal/priority=] to |init|["{{TaskControllerInit/priority}}"].
   1. Set [=this's=] [=AbortController/signal=] to |signal|.
 </div>
 


### PR DESCRIPTION
Closes #26.

Previously, the TaskController constructor had a single optional priority parameter. While there is a low likelihood that we'll add a parameter to this or AbortController, changing this to a dictionary helps future-proof the API in the case that we do (per https://w3ctag.github.io/design-principles/#prefer-dict-to-bool).