### PR TITLE
Mark the scheduler attribute as [Replaceable]

### DIFF
--- a/spec/patches.md
+++ b/spec/patches.md
@@ -12,7 +12,7 @@ is initialized as a new {{Scheduler}}.
 
 <pre class='idl'>
   partial interface mixin WindowOrWorkerGlobalScope {
-    readonly attribute Scheduler scheduler;
+    [Replaceable] readonly attribute Scheduler scheduler;
   };
 </pre>
 


### PR DESCRIPTION
This makes the spec consistent Chromium's implementation, which was
was the intended behavior to avoid potential name conflicts with the
generic term.

Closes #58.