### PR TITLE
Fix broken HTML links

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -83,14 +83,14 @@ spec:html; type:dfn; for:/; text:task queue
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/;
   type: attribute;
     text: steps; for:task; url: webappapis.html#concept-task-steps
-    text: source; for:task; url: webappapis.html#concept-source
-    text: document; for:task; url: webappapis.html#concept-document
+    text: source; for:task; url: webappapis.html#concept-task-source
+    text: document; for:task; url: webappapis.html#concept-task-document
     text: script evaluation environment settings object set; for:task; url: webappapis.html#script-evaluation-environment-settings-object-set
     text: associated Document; for:Window; url: window-object.html#concept-document-window
   type: dfn
     text: runnable; for:task; url: webappapis.html#concept-task-runnable
 spec: dom; urlPrefix: https://dom.spec.whatwg.org/#;
-  type: dfn; 
+  type: dfn;
     text: signal; for: AbortController; url: abortcontroller-signal
 spec: requestidlecallback; urlPrefix: https://www.w3.org/TR/requestidlecallback/#;
   type: method;


### PR DESCRIPTION
Fixes #66.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/68.html" title="Last updated on Mar 14, 2023, 10:27 PM UTC (a3f5f7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/68/08ddfbb...shaseley:a3f5f7f.html" title="Last updated on Mar 14, 2023, 10:27 PM UTC (a3f5f7f)">Diff</a>