### PR TITLE
Fix line breaks

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -105,13 +105,13 @@ integrate the API into existing code that uses {{AbortSignal|AbortSignals}}.
 </dl>
 
 
-A {{Scheduler}} object has an associated <dfn for="Scheduler">static priority
-task queue map</dfn>, which is a [=map=] from {{TaskPriority}} to [=scheduler
-task queue=].  This map is initialized to a new empty [=map=].
+A {{Scheduler}} object has an associated <dfn for="Scheduler">static priority task queue map</dfn>,
+which is a [=map=] from {{TaskPriority}} to [=scheduler task queue=]. This map
+is initialized to a new empty [=map=].
 
-A {{Scheduler}} object has an associated <dfn for="Scheduler">dynamic priority
-task queue map</dfn>, which is a [=map=] from {{TaskSignal}} to [=scheduler
-task queue=]. This map is initialized to a new empty [=map=].
+A {{Scheduler}} object has an associated <dfn for="Scheduler">dynamic priority task queue map</dfn>,
+which is a [=map=] from {{TaskSignal}} to [=scheduler task queue=]. This map is
+initialized to a new empty [=map=].
 
 Note: We implement *dynamic prioritization* by enqueuing tasks associated with
 a specific {{TaskSignal}} into the same [=scheduler task queue=], and changing
@@ -137,8 +137,8 @@ single per-{{TaskPriority}} [=scheduler task queue=], and move tasks between
 changes more complex.
 
 
-A {{Scheduler}} object has a numeric <dfn for="Scheduler">next enqueue
-order</dfn> which is initialized to 1.
+A {{Scheduler}} object has a numeric <dfn for="Scheduler">next enqueue order</dfn>
+which is initialized to 1.
 
 Note: The [=Scheduler/next enqueue order=] is a strictly increasing number that
 is used to determine task execution order across [=scheduler task queues=] of the

--- a/spec/security.md
+++ b/spec/security.md
@@ -45,10 +45,10 @@ amount of information as described below.
 Concretely, an attacker would be able to detect when other tasks are executed
 by the browser by either flooding the system with tasks or by recursively
 scheduling tasks. This is a [known attack](https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/vila)
-that can be executed with existing APIs like {{Window/postMessage(message,
-options)|postMessage()}}. The tasks that run instead of the attacker's can be
-tasks in other event loops as well as other tasks in the attacker's event loop,
-including internal UA tasks (e.g. garbage collection).
+that can be executed with existing APIs like {{Window/postMessage(message, options)|postMessage()}}.
+The tasks that run instead of the attacker's can be tasks in other event loops
+as well as other tasks in the attacker's event loop, including internal UA tasks
+(e.g. garbage collection).
 
 Assuming the attacker can determine with a high degree of probability that the
 task executing is in another event loop, then the question becomes what


### PR DESCRIPTION
Editorial fix: remove line breaks in definitions and references. The new bikeshed HTML parser does not insert spaces, which broke linking.