### PR TITLE
Add TaskSignal.any()

### DIFF
--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -129,9 +129,9 @@ A {{TaskSignal}} object has associated <dfn for=TaskSignal>priority change algor
 (a [=set=] of algorithms that are to be executed when its [=TaskSignal/priority changing=] value
 is true), which is initially empty.
 
-A {{TaskSignal}} object has an associated <dfn for=TaskSignal>source signal</dfn> {{TaskSignal}} (a
-weak reference to a {{TaskSignal}} that the object is dependent on for its [=TaskSignal/priority=]),
-which is initially null.
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>source signal</dfn> (a weak refernece
+to a {{TaskSignal}} that the object is dependent on for its [=TaskSignal/priority=]), which is
+initially null.
 
 A {{TaskSignal}} object has associated <dfn for=TaskSignal>dependent signals</dfn> (a weak [=set=]
 of {{TaskSignal}} objects that are dependent on the object for their [=TaskSignal/priority=]), which

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -90,8 +90,14 @@ The `TaskSignal` Interface {#sec-task-signal}
 ---------------------
 
 <pre class='idl'>
+  dictionary TaskSignalAnyInit {
+    (TaskPriority or TaskSignal) priority = "user-visible";
+  };
+
   [Exposed=(Window, Worker)]
   interface TaskSignal : AbortSignal {
+    [NewObject] static TaskSignal _any(sequence&lt;AbortSignal> signals, optional TaskSignalAnyInit init = {});
+
     readonly attribute TaskPriority priority;
 
     attribute EventHandler onprioritychange;
@@ -103,10 +109,15 @@ accept an {{AbortSignal}}. Additionally, {{Scheduler/postTask()}} accepts an
 {{AbortSignal}}, which can be useful if dynamic prioritization is not needed.
 
 <dl class="domintro non-normative">
+  <dt><code>TaskSignal . <a method for=TaskSignal lt="any(signals, init)">any</a>(|signals|, |init|)</code>
+  <dd>Returns a {{TaskSignal}} instance which will be aborted if any of |signals| is aborted. Its
+  [=AbortSignal/abort reason=] will be set to whichever one of |signals| cause it to be aborted. The
+  signal's [=TaskSignal/priority=] will be determined by |init|'s {{TaskSignalAnyInit/priority}},
+  which can either be a fixed {{TaskPriority}} or a {{TaskSignal}}, in which case the new signal's
+  [=TaskSignal/priority=] will change along with this signal.
+
   <dt><code>signal . {{TaskSignal/priority}}</code>
-  <dd>
-    <p>Returns the {{TaskPriority}} of the signal.
-  </dd>
+  <dd><p>Returns the {{TaskPriority}} of the signal.
 </dl>
 
 A {{TaskSignal}} object has an associated {{TaskPriority}}
@@ -120,6 +131,21 @@ which is a [=set=] of algorithms, initialized to a new empty [=set=]. These
 algorithms are to be executed when its [=TaskSignal/priority changing=] value
 is true.
 
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>parent signal</dfn> {{TaskSignal}},
+intially set to null and stored as a weak reference. If an object's [=TaskSignal/parent signal=] is
+not null, the object is dependent on its parent for its priority.
+
+A {{TaskSignal}} object has associated <dfn for=TaskSignal>child signals</dfn>, which is a [=set=]
+of {{TaskSignal}} objects, initialized to a new empty [=set=]. These signals are dependent on the
+object for their priority.
+
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>fixed priority</dfn>
+[=boolean=], intially set to false.
+
+A {{TaskSignal}} <dfn for=TaskSignal lt="has fixed priority|have fixed priority">has fixed priority</dfn>
+if its [=TaskSignal/fixed priority=] is true or it is a [=AbortSignal/composite=] signal with a null
+[=TaskSignal/parent signal=].
+
 The <dfn attribute for="TaskSignal">priority</dfn> getter steps are to return
 [=this=]'s [=TaskSignal/priority=].
 
@@ -131,6 +157,33 @@ is an [=event handler IDL attribute=] for the `onprioritychange`
 To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
 {{TaskSignal}} object |signal|, [=set/append=] |algorithm| to |signal|'s
 [=TaskSignal/priority change algorithms=].
+
+<div algorithm>
+  The static <dfn method for=TaskSignal><code>any(|signals|, |init|)</code></dfn> method steps are:
+
+  1. Let |resultSignal| be the result of <a for=AbortSignal>creating a composite signal</a> from
+     <var>signals</var> with the {{TaskSignal}} interface.
+  1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
+    1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
+    1. Set |resultSignal|'s [=TaskSignal/fixed priority=] to true.
+  1. Otherwise:
+    1. Set |parentSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
+    1. Set |resultSignal|'s [=TaskSignal/priority=] to |parentSignal|'s [=TaskSignal/priority=].
+    1. Set |resultSignal|'s [=TaskSignal/fixed priority=] to |parentSignal|'s
+       [=TaskSignal/fixed priority=].
+    1. If |parentSignal| does not [=TaskSignal/have fixed priority=], then:
+      1. If |parentSignal|'s [=AbortSignal/composite=] is true, then set |parentSignal| to
+         |parentSignal|'s [=TaskSignal/parent signal=].
+      1. Assert: |parentSignal| is not [=AbortSignal/composite=].
+      1. Set |resultSignal|'s [=TaskSignal/parent signal=] to |parentSignal|.
+      1. [=set/Append=] |resultSignal| to |parentSignal|'s [=TaskSignal/child signals=].
+  1. Return |resultSignal|.
+
+  Note: [=TaskSignal/Child signals=] need to be held by strong reference as long as the parent can
+  still [=TaskSignal/signal priority change=] and the child has any {{TaskSignal/prioritychange}}
+  event listeners registered. A {{TaskSignal}} can no longer [=TaskSignal/signal priority change=]
+  if it is the {{AbortController/signal}} of a {{TaskController}} that has been garbage collected.
+</div>
 
 <div algorithm>
   To <dfn for="TaskSignal">signal priority change</dfn> on a {{TaskSignal}}
@@ -147,6 +200,8 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
   1. [=Fire an event=] named {{TaskSignal/prioritychange}} at |signal| using
      {{TaskPriorityChangeEvent}}, with its {{TaskPriorityChangeEvent/previousPriority}}
      attribute initialized to |previousPriority|.
+  1. [=list/iterate|For each=] |childSignal| of |signal|'s [=TaskSignal/child signals=],
+     [=TaskSignal/signal priority change=] on |childSignal| with |priority|.
   1. Set |signal|'s [=TaskSignal/priority changing=] to false.
 </div>
 

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -137,6 +137,9 @@ A {{TaskSignal}} object has associated <dfn for=TaskSignal>dependent signals</df
 of {{TaskSignal}} objects that are dependent on the object for their [=TaskSignal/priority=]), which
 is initially empty.
 
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>dependent</dfn> (a
+boolean), which is initially false.
+
 <br>
 
 The <dfn attribute for="TaskSignal">priority</dfn> getter steps are to return
@@ -154,22 +157,23 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
 <br>
 
 A {{TaskSignal}} <dfn for=TaskSignal lt="has fixed priority|have fixed priority">has fixed priority</dfn>
-if it is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source signal=].
+if it is a [=TaskSignal/dependent=] signal with a null [=TaskSignal/source signal=].
 
 <div algorithm>
   The static <dfn method for=TaskSignal><code>any(|signals|, |init|)</code></dfn> method steps are:
 
-  1. Let |resultSignal| be the result of <a for=AbortSignal>creating a composite signal</a> from
+  1. Let |resultSignal| be the result of <a for=AbortSignal>creating a dependent signal</a> from
      |signals| using the {{TaskSignal}} interface and the [=current realm=].
+  1. Set |resultSignal|'s [=TaskSignal/dependent=] to true.
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
   1. Otherwise:
     1. Set |sourceSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |sourceSignal|'s [=TaskSignal/priority=].
     1. If |sourceSignal| does not [=TaskSignal/have fixed priority=], then:
-      1. If |sourceSignal|'s [=AbortSignal/composite=] is true, then set |sourceSignal| to
+      1. If |sourceSignal|'s [=TaskSignal/dependent=] is true, then set |sourceSignal| to
          |sourceSignal|'s [=TaskSignal/source signal=].
-      1. Assert: |sourceSignal| is not [=AbortSignal/composite=].
+      1. Assert: |sourceSignal| is not [=TaskSignal/dependent=].
       1. Set |resultSignal|'s [=TaskSignal/source signal=] to a weak reference to |sourceSignal|.
       1. [=set/Append=] |resultSignal| to |sourceSignal|'s [=TaskSignal/dependent signals=].
   1. Return |resultSignal|.
@@ -197,7 +201,7 @@ if it is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source sign
 
 ### Garbage Collection {#sec-task-signal-garbage-collection}
 
-A [=AbortSignal/composite=] {{TaskSignal}} object must not be garbage collected while its
+A [=TaskSignal/dependent=] {{TaskSignal}} object must not be garbage collected while its
 [=TaskSignal/source signal=] is non-null and it has registered event listeners for its
 {{TaskSignal/prioritychange}} event or its [=TaskSignal/priority change algorithms=] is non-empty.
 

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -168,7 +168,7 @@ if it is a [=TaskSignal/dependent=] signal with a null [=TaskSignal/source signa
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
   1. Otherwise:
-    1. Set |sourceSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
+    1. Let |sourceSignal| be |init|["{{TaskSignalAnyInit/priority}}"].
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |sourceSignal|'s [=TaskSignal/priority=].
     1. If |sourceSignal| does not [=TaskSignal/have fixed priority=], then:
       1. If |sourceSignal|'s [=TaskSignal/dependent=] is true, then set |sourceSignal| to
@@ -199,7 +199,7 @@ if it is a [=TaskSignal/dependent=] signal with a null [=TaskSignal/source signa
   1. Set |signal|'s [=TaskSignal/priority changing=] to false.
 </div>
 
-### Garbage Collection {#sec-task-signal-garbage-collection}
+### Garbage Collection ### {#sec-task-signal-garbage-collection}
 
 A [=TaskSignal/dependent=] {{TaskSignal}} object must not be garbage collected while its
 [=TaskSignal/source signal=] is non-null and it has registered event listeners for its

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -177,7 +177,7 @@ if it is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source sign
 
 <div algorithm>
   To <dfn for="TaskSignal">signal priority change</dfn> on a {{TaskSignal}}
-  object |signal|, given a {{TaskPriority}} |priority|, run the following steps:
+  object |signal|, given a {{TaskPriority}} |priority|:
 
   1. If |signal|'s [=TaskSignal/priority changing=] is true, then [=exception/throw=]
      a "{{NotAllowedError!!exception}}" {{DOMException}}.

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -111,8 +111,8 @@ accept an {{AbortSignal}}. Additionally, {{Scheduler/postTask()}} accepts an
 <dl class="domintro non-normative">
   <dt><code>TaskSignal . <a method for=TaskSignal lt="any(signals, init)">any</a>(|signals|, |init|)</code>
   <dd>Returns a {{TaskSignal}} instance which will be aborted if any of |signals| is aborted. Its
-  [=AbortSignal/abort reason=] will be set to whichever one of |signals| cause it to be aborted. The
-  signal's [=TaskSignal/priority=] will be determined by |init|'s {{TaskSignalAnyInit/priority}},
+  [=AbortSignal/abort reason=] will be set to whichever one of |signals| caused it to be aborted.
+  The signal's [=TaskSignal/priority=] will be determined by |init|'s {{TaskSignalAnyInit/priority}},
   which can either be a fixed {{TaskPriority}} or a {{TaskSignal}}, in which case the new signal's
   [=TaskSignal/priority=] will change along with this signal.
 
@@ -131,20 +131,16 @@ which is a [=set=] of algorithms, initialized to a new empty [=set=]. These
 algorithms are to be executed when its [=TaskSignal/priority changing=] value
 is true.
 
-A {{TaskSignal}} object has an associated <dfn for=TaskSignal>parent signal</dfn> {{TaskSignal}},
-intially set to null and stored as a weak reference. If an object's [=TaskSignal/parent signal=] is
-not null, the object is dependent on its parent for its priority.
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>source signal</dfn> {{TaskSignal}},
+which is a weak reference to a {{TaskSignal}} that the object is dependent on for its
+[=TaskSignal/priority=]. Unless specified otherwise, its value is null.
 
-A {{TaskSignal}} object has associated <dfn for=TaskSignal>child signals</dfn>, which is a [=set=]
-of {{TaskSignal}} objects, initialized to a new empty [=set=]. These signals are dependent on the
-object for their priority.
-
-A {{TaskSignal}} object has an associated <dfn for=TaskSignal>fixed priority</dfn>
-[=boolean=], intially set to false.
+A {{TaskSignal}} object has associated <dfn for=TaskSignal>dependent signals</dfn>, which is a
+[=set=] of weak references to {{TaskSignal}} objects that are dependent on it for their
+[=TaskSignal/priority=]. Unless specified otherwise, its value is the empty set.
 
 A {{TaskSignal}} <dfn for=TaskSignal lt="has fixed priority|have fixed priority">has fixed priority</dfn>
-if its [=TaskSignal/fixed priority=] is true or it is a [=AbortSignal/composite=] signal with a null
-[=TaskSignal/parent signal=].
+is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source signal=].
 
 The <dfn attribute for="TaskSignal">priority</dfn> getter steps are to return
 [=this=]'s [=TaskSignal/priority=].
@@ -162,27 +158,19 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
   The static <dfn method for=TaskSignal><code>any(|signals|, |init|)</code></dfn> method steps are:
 
   1. Let |resultSignal| be the result of <a for=AbortSignal>creating a composite signal</a> from
-     <var>signals</var> with the {{TaskSignal}} interface.
+     |signals| with the {{TaskSignal}} interface.
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
-    1. Set |resultSignal|'s [=TaskSignal/fixed priority=] to true.
   1. Otherwise:
-    1. Set |parentSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
-    1. Set |resultSignal|'s [=TaskSignal/priority=] to |parentSignal|'s [=TaskSignal/priority=].
-    1. Set |resultSignal|'s [=TaskSignal/fixed priority=] to |parentSignal|'s
-       [=TaskSignal/fixed priority=].
-    1. If |parentSignal| does not [=TaskSignal/have fixed priority=], then:
-      1. If |parentSignal|'s [=AbortSignal/composite=] is true, then set |parentSignal| to
-         |parentSignal|'s [=TaskSignal/parent signal=].
-      1. Assert: |parentSignal| is not [=AbortSignal/composite=].
-      1. Set |resultSignal|'s [=TaskSignal/parent signal=] to |parentSignal|.
-      1. [=set/Append=] |resultSignal| to |parentSignal|'s [=TaskSignal/child signals=].
+    1. Set |sourceSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
+    1. Set |resultSignal|'s [=TaskSignal/priority=] to |sourceSignal|'s [=TaskSignal/priority=].
+    1. If |sourceSignal| does not [=TaskSignal/have fixed priority=], then:
+      1. If |sourceSignal|'s [=AbortSignal/composite=] is true, then set |sourceSignal| to
+         |sourceSignal|'s [=TaskSignal/source signal=].
+      1. Assert: |sourceSignal| is not [=AbortSignal/composite=].
+      1. Set |resultSignal|'s [=TaskSignal/source signal=] to |sourceSignal|.
+      1. [=set/Append=] |resultSignal| to |sourceSignal|'s [=TaskSignal/dependent signals=].
   1. Return |resultSignal|.
-
-  Note: [=TaskSignal/Child signals=] need to be held by strong reference as long as the parent can
-  still [=TaskSignal/signal priority change=] and the child has any {{TaskSignal/prioritychange}}
-  event listeners registered. A {{TaskSignal}} can no longer [=TaskSignal/signal priority change=]
-  if it is the {{AbortController/signal}} of a {{TaskController}} that has been garbage collected.
 </div>
 
 <div algorithm>
@@ -200,10 +188,16 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
   1. [=Fire an event=] named {{TaskSignal/prioritychange}} at |signal| using
      {{TaskPriorityChangeEvent}}, with its {{TaskPriorityChangeEvent/previousPriority}}
      attribute initialized to |previousPriority|.
-  1. [=list/iterate|For each=] |childSignal| of |signal|'s [=TaskSignal/child signals=],
-     [=TaskSignal/signal priority change=] on |childSignal| with |priority|.
+  1. [=list/iterate|For each=] |dependentSignal| of |signal|'s [=TaskSignal/dependent signals=],
+     [=TaskSignal/signal priority change=] on |dependentSignal| with |priority|.
   1. Set |signal|'s [=TaskSignal/priority changing=] to false.
 </div>
+
+### Garbage Collection {#sec-task-signal-garbage-collection}
+
+A [=AbortSignal/composite=] {{TaskSignal}} object must not be garbage collected while its
+[=TaskSignal/source signal=] is non-null and it has registered event listeners for its
+{{TaskSignal/prioritychange}} event or its [=TaskSignal/priority change algorithms=] is non-empty.
 
 Examples {#sec-controlling-tasks-examples}
 ---------------------

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -120,27 +120,24 @@ accept an {{AbortSignal}}. Additionally, {{Scheduler/postTask()}} accepts an
   <dd><p>Returns the {{TaskPriority}} of the signal.
 </dl>
 
-A {{TaskSignal}} object has an associated {{TaskPriority}}
-<dfn for=TaskSignal>priority</dfn>.
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>priority</dfn> (a {{TaskPriority}}).
 
-A {{TaskSignal}} object has an associated <dfn for=TaskSignal>priority changing</dfn>
-[=boolean=], intially set to false.
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>priority changing</dfn> (a
+[=boolean=]), which is intially set to false.
 
 A {{TaskSignal}} object has associated <dfn for=TaskSignal>priority change algorithms</dfn>,
-which is a [=set=] of algorithms, initialized to a new empty [=set=]. These
-algorithms are to be executed when its [=TaskSignal/priority changing=] value
-is true.
+(a [=set=] of algorithms that are to be executed when its [=TaskSignal/priority changing=] value
+is true), which is initially empty.
 
-A {{TaskSignal}} object has an associated <dfn for=TaskSignal>source signal</dfn> {{TaskSignal}},
-which is a weak reference to a {{TaskSignal}} that the object is dependent on for its
-[=TaskSignal/priority=]. Unless specified otherwise, its value is null.
+A {{TaskSignal}} object has an associated <dfn for=TaskSignal>source signal</dfn> {{TaskSignal}} (a
+weak reference to a {{TaskSignal}} that the object is dependent on for its [=TaskSignal/priority=]),
+which is initially null.
 
-A {{TaskSignal}} object has associated <dfn for=TaskSignal>dependent signals</dfn>, which is a
-[=set=] of weak references to {{TaskSignal}} objects that are dependent on it for their
-[=TaskSignal/priority=]. Unless specified otherwise, its value is the empty set.
+A {{TaskSignal}} object has associated <dfn for=TaskSignal>dependent signals</dfn> (a weak [=set=]
+of {{TaskSignal}} objects that are dependent on the object for their [=TaskSignal/priority=]), which
+is initially empty.
 
-A {{TaskSignal}} <dfn for=TaskSignal lt="has fixed priority|have fixed priority">has fixed priority</dfn>
-is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source signal=].
+<br>
 
 The <dfn attribute for="TaskSignal">priority</dfn> getter steps are to return
 [=this=]'s [=TaskSignal/priority=].
@@ -154,11 +151,16 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
 {{TaskSignal}} object |signal|, [=set/append=] |algorithm| to |signal|'s
 [=TaskSignal/priority change algorithms=].
 
+<br>
+
+A {{TaskSignal}} <dfn for=TaskSignal lt="has fixed priority|have fixed priority">has fixed priority</dfn>
+if it is a [=AbortSignal/composite=] signal with a null [=TaskSignal/source signal=].
+
 <div algorithm>
   The static <dfn method for=TaskSignal><code>any(|signals|, |init|)</code></dfn> method steps are:
 
   1. Let |resultSignal| be the result of <a for=AbortSignal>creating a composite signal</a> from
-     |signals| with the {{TaskSignal}} interface.
+     |signals| using the {{TaskSignal}} interface and the [=current realm=].
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
   1. Otherwise:
@@ -168,7 +170,7 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a
       1. If |sourceSignal|'s [=AbortSignal/composite=] is true, then set |sourceSignal| to
          |sourceSignal|'s [=TaskSignal/source signal=].
       1. Assert: |sourceSignal| is not [=AbortSignal/composite=].
-      1. Set |resultSignal|'s [=TaskSignal/source signal=] to |sourceSignal|.
+      1. Set |resultSignal|'s [=TaskSignal/source signal=] to a weak reference to |sourceSignal|.
       1. [=set/Append=] |resultSignal| to |sourceSignal|'s [=TaskSignal/dependent signals=].
   1. Return |resultSignal|.
 </div>

--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -168,7 +168,7 @@ if it is a [=TaskSignal/dependent=] signal with a null [=TaskSignal/source signa
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].
   1. Otherwise:
-    1. Let |sourceSignal| be |init|["{{TaskSignalAnyInit/priority}}"].
+    1. Set |sourceSignal| to |init|["{{TaskSignalAnyInit/priority}}"].
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |sourceSignal|'s [=TaskSignal/priority=].
     1. If |sourceSignal| does not [=TaskSignal/have fixed priority=], then:
       1. If |sourceSignal|'s [=TaskSignal/dependent=] is true, then set |sourceSignal| to
@@ -199,7 +199,7 @@ if it is a [=TaskSignal/dependent=] signal with a null [=TaskSignal/source signa
   1. Set |signal|'s [=TaskSignal/priority changing=] to false.
 </div>
 
-### Garbage Collection ### {#sec-task-signal-garbage-collection}
+### Garbage Collection {#sec-task-signal-garbage-collection}
 
 A [=TaskSignal/dependent=] {{TaskSignal}} object must not be garbage collected while its
 [=TaskSignal/source signal=] is non-null and it has registered event listeners for its

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -89,10 +89,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/;
     text: associated Document; for:Window; url: window-object.html#concept-document-window
   type: dfn
     text: runnable; for:task; url: webappapis.html#concept-task-runnable
-spec: dom; urlPrefix: https://dom.spec.whatwg.org/#;
+spec: dom; urlPrefix: https://whatpr.org/dom/1152.html#
   type: dfn;
-    text: composite; for:AbortSignal; url: abortsignal-composite
-    text: creating a composite signal; for:AbortSignal; url: create-a-composite-abort-signal
+    text: creating a dependent signal; for:AbortSignal; url: create-a-dependent-abort-signal
     text: signal; for: AbortController; url: abortcontroller-signal
 spec: requestidlecallback; urlPrefix: https://www.w3.org/TR/requestidlecallback/#;
   type: method;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -89,7 +89,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/;
     text: associated Document; for:Window; url: window-object.html#concept-document-window
   type: dfn
     text: runnable; for:task; url: webappapis.html#concept-task-runnable
-spec: dom; urlPrefix: https://whatpr.org/dom/1152.html#
+spec: dom; urlPrefix: https://dom.spec.whatwg.org/#
   type: dfn;
     text: creating a dependent signal; for:AbortSignal; url: create-a-dependent-abort-signal
     text: signal; for: AbortController; url: abortcontroller-signal

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -91,10 +91,15 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/;
     text: runnable; for:task; url: webappapis.html#concept-task-runnable
 spec: dom; urlPrefix: https://dom.spec.whatwg.org/#;
   type: dfn;
+    text: composite; for:AbortSignal; url: abortsignal-composite
+    text: creating a composite signal; for:AbortSignal; url: create-a-composite-abort-signal
     text: signal; for: AbortController; url: abortcontroller-signal
 spec: requestidlecallback; urlPrefix: https://www.w3.org/TR/requestidlecallback/#;
   type: method;
     text: requestIdleCallback(); for: Window; url: dom-window-requestidlecallback
+spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/#;
+  type: dfn
+    text: current realm; url: current-realm
 </pre>
 
 <pre class=include>

--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -264,21 +264,21 @@ see [whatwg/html#5925](https://github.com/whatwg/html/issues/5925).
   for a {{Scheduler}} |scheduler| given an {{AbortSignal}} or null |signal|, and
   a {{TaskPriority}} or null |priority|:
 
-  1. If |priority| is null, |signal| is not null and [=implements=] the {{TaskSignal}}
-     interface, and |signal| [=TaskSignal/has fixed priority=], then set |priority| to
-     |signal|'s [=TaskSignal/priority=].
   1. If |priority| is null and |signal| is not null and |signal| [=implements=]
      the {{TaskSignal}} interface, then
-    1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not
-       [=map/contain=] |signal|, then
-      1. Let |queue| be the result of [=creating a scheduler task queue=] given
-         |signal|'s [=TaskSignal/priority=].
-      1. Set [=Scheduler/dynamic priority task queue map=][|signal|] to |queue|.
-      1. [=TaskSignal/Add a priority change algorithm=] to |signal| that
-         runs the following steps:
-        1. Set |queue|'s [=scheduler task queue/priority=] to |signal|'s
-           {{TaskSignal/priority}}.
-    1. Return [=Scheduler/dynamic priority task queue map=][|signal|].
+    1. If |signal| [=TaskSignal/has fixed priority=], then set |priority| to |signal|'s
+       [=TaskSignal/priority=].
+    1. Otherwise:
+        1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not
+           [=map/contain=] |signal|, then
+          1. Let |queue| be the result of [=creating a scheduler task queue=] given
+             |signal|'s [=TaskSignal/priority=].
+          1. Set [=Scheduler/dynamic priority task queue map=][|signal|] to |queue|.
+          1. [=TaskSignal/Add a priority change algorithm=] to |signal| that
+             runs the following steps:
+            1. Set |queue|'s [=scheduler task queue/priority=] to |signal|'s
+               {{TaskSignal/priority}}.
+        1. Return [=Scheduler/dynamic priority task queue map=][|signal|].
   1. Otherwise |priority| is used to determine the task queue:
     1. If |priority| is null, set |priority| to "{{TaskPriority/user-visible}}".
     1. If |scheduler|'s [=Scheduler/static priority task queue map=] does not

--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -264,6 +264,9 @@ see [whatwg/html#5925](https://github.com/whatwg/html/issues/5925).
   for a {{Scheduler}} |scheduler| given an {{AbortSignal}} or null |signal|, and
   a {{TaskPriority}} or null |priority|:
 
+  1. If |priority| is null, |signal| is not null and [=implements=] the {{TaskSignal}}
+     interface, and |signal| [=TaskSignal/has fixed priority=], then set |priority| to
+     |signal|'s [=TaskSignal/priority=].
   1. If |priority| is null and |signal| is not null and |signal| [=implements=]
      the {{TaskSignal}} interface, then
     1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not

--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -264,11 +264,11 @@ see [whatwg/html#5925](https://github.com/whatwg/html/issues/5925).
   for a {{Scheduler}} |scheduler| given an {{AbortSignal}} or null |signal|, and
   a {{TaskPriority}} or null |priority|:
 
-  1. If |priority| is null, |signal| is not null and [=implements=] the {{TaskSignal}}
-     interface, and |signal| [=TaskSignal/has fixed priority=], then set |priority| to
-     |signal|'s [=TaskSignal/priority=].
-  1. If |priority| is null and |signal| is not null and |signal| [=implements=]
-     the {{TaskSignal}} interface, then
+  1. If |priority| is null, |signal| is not null and [=implements=] the {{TaskSignal}} interface,
+     and |signal| [=TaskSignal/has fixed priority=], then set |priority| to |signal|'s
+     [=TaskSignal/priority=].
+  1. If |priority| is null and |signal| is not null and [=implements=] the {{TaskSignal}} interface,
+     then
     1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not
        [=map/contain=] |signal|, then
       1. Let |queue| be the result of [=creating a scheduler task queue=] given

--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -264,21 +264,21 @@ see [whatwg/html#5925](https://github.com/whatwg/html/issues/5925).
   for a {{Scheduler}} |scheduler| given an {{AbortSignal}} or null |signal|, and
   a {{TaskPriority}} or null |priority|:
 
+  1. If |priority| is null, |signal| is not null and [=implements=] the {{TaskSignal}}
+     interface, and |signal| [=TaskSignal/has fixed priority=], then set |priority| to
+     |signal|'s [=TaskSignal/priority=].
   1. If |priority| is null and |signal| is not null and |signal| [=implements=]
      the {{TaskSignal}} interface, then
-    1. If |signal| [=TaskSignal/has fixed priority=], then set |priority| to |signal|'s
-       [=TaskSignal/priority=].
-    1. Otherwise:
-        1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not
-           [=map/contain=] |signal|, then
-          1. Let |queue| be the result of [=creating a scheduler task queue=] given
-             |signal|'s [=TaskSignal/priority=].
-          1. Set [=Scheduler/dynamic priority task queue map=][|signal|] to |queue|.
-          1. [=TaskSignal/Add a priority change algorithm=] to |signal| that
-             runs the following steps:
-            1. Set |queue|'s [=scheduler task queue/priority=] to |signal|'s
-               {{TaskSignal/priority}}.
-        1. Return [=Scheduler/dynamic priority task queue map=][|signal|].
+    1. If |scheduler|'s [=Scheduler/dynamic priority task queue map=] does not
+       [=map/contain=] |signal|, then
+      1. Let |queue| be the result of [=creating a scheduler task queue=] given
+         |signal|'s [=TaskSignal/priority=].
+      1. Set [=Scheduler/dynamic priority task queue map=][|signal|] to |queue|.
+      1. [=TaskSignal/Add a priority change algorithm=] to |signal| that
+         runs the following steps:
+        1. Set |queue|'s [=scheduler task queue/priority=] to |signal|'s
+           {{TaskSignal/priority}}.
+    1. Return [=Scheduler/dynamic priority task queue map=][|signal|].
   1. Otherwise |priority| is used to determine the task queue:
     1. If |priority| is null, set |priority| to "{{TaskPriority/user-visible}}".
     1. If |scheduler|'s [=Scheduler/static priority task queue map=] does not


### PR DESCRIPTION
Specialization of [`AbortSignal.any()`](https://github.com/whatwg/dom/pull/1152) for TaskSignal.any(). It supports creating a composite signal with multiple abort sources and either a fixed priority or single priority source. The spec is similar to `AbortSignal.any()` and uses the internal constructor for the abort aspect.

Tests: https://github.com/web-platform-tests/wpt/tree/master/scheduler (task-signal-any*).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/72.html" title="Last updated on May 17, 2023, 5:36 PM UTC (e816db8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/72/38dd556...shaseley:e816db8.html" title="Last updated on May 17, 2023, 5:36 PM UTC (e816db8)">Diff</a>