### PR TITLE
Clean up abort algorithms and task queue map entries

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -268,10 +268,10 @@ A <dfn>task handle</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Let |priority| be |options|["{{SchedulerPostTaskOptions/priority}}"] if
      |options|["{{SchedulerPostTaskOptions/priority}}"] [=map/exists=], or otherwise null.
   1. Let |enqueueSteps| be the following steps:
-    1. Let |queue| be the result of [=selecting the scheduler task queue=] for |scheduler| given
-       |signal| and |priority|.
-    1. [=Schedule a task to invoke a callback=] for |scheduler| given |queue|, |callback|, |result|,
-       and |handle|.
+    1. Set |handle|'s [=task handle/queue=] to the result of [=selecting the scheduler task queue=]
+       for |scheduler| given |signal| and |priority|.
+    1. [=Schedule a task to invoke a callback=] for |scheduler| given |callback|, |result|, and
+       |handle|.
   1. Let |delay| be |options|["{{SchedulerPostTaskOptions/delay}}"].
   1. If |delay| is greater than 0, then [=run steps after a timeout=] given |scheduler|'s [=relevant
      global object=], "`scheduler-postTask`", |delay|, and the following steps:
@@ -314,21 +314,19 @@ Issue: [=Run steps after a timeout=] doesn't necessarily account for suspension;
 
 <div algorithm>
   To <dfn>schedule a task to invoke a callback</dfn> for {{Scheduler}} |scheduler| given a
-  [=scheduler task queue=] |queue|, a {{SchedulerPostTaskCallback}} |callback|, a promise |result|,
-  and a [=task handle=] |handle|:
+  {{SchedulerPostTaskCallback}} |callback|, a promise |result|, and a [=task handle=] |handle|:
 
   1. Let |global| be the [=relevant global object=] for |scheduler|.
   1. Let |document| be |global|'s <a attribute for="Window">associated `Document`</a> if |global| is
      a {{Window}} object; otherwise null.
   1. Let |enqueue order| be |scheduler|'s [=Scheduler/next enqueue order=].
   1. Increment |scheduler|'s [=Scheduler/next enqueue order=] by 1.
-  1. Let |task| be the result of [=queuing a scheduler task=] on |queue| given |enqueue order|,
-     the [=posted task task source=], and |document|, and that performs the following steps:
+  1. Set |handle|'s [=task handle/task=] to the result of [=queuing a scheduler task=] on |handle|'s
+     [=task handle/queue=] given |enqueue order|, the [=posted task task source=], and |document|,
+     and that performs the following steps:
     1. Let |callback result| be the result of [=invoking=] |callback|. If that threw an exception,
        then [=reject=] |result| with that, otherwise resolve |result| with |callback result|.
     1. Run |handle|'s [=task handle/task complete steps=].
-  1. Set |handle|'s [=task handle/task=] to |task|.
-  1. Set |handle|'s [=task handle/queue=] to |queue|.
 
   Issue: Because this algorithm can be called from [=in parallel=] steps, parts of this and other
   algorithms are racy. Specifically, the [=Scheduler/next enqueue order=] should be updated


### PR DESCRIPTION
This introduces removal of abort algorithms and task queue map entries on abort and task completion:
 - Add a helper struct (task handle) to store state and algorithms needed to clean up on abort/task complete. It was a bit cleaner to keep this all together.
 - On abort and task complete, remove the task queue map entry if the queue became empty
 - On task complete, remove the abort algorithm
 - On abort, remove the pending task

Notes:
 1. This also fixes a spec bug where it was possible for delayed tasks not to be aborted if the abort happened while waiting to queue the task. This is fixed here by moving up the point where we add the abort algorithm and conditionally and adjusting the algorithm to handle the case where the task hasn't been queued yet (during delay).

 2. For delayed tasks, getting the destination task queue is deferred until actually queuing the task (after the delay expires). It's important to wait to ensure the map entry exists when queuing the task.

 3. Chromium removes both abort algorithms and task queues lazily during GC, which is another valid approach (these are not web observable).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/84.html" title="Last updated on Apr 9, 2024, 9:40 PM UTC (b3b6a19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/84/d1bf8ab...shaseley:b3b6a19.html" title="Last updated on Apr 9, 2024, 9:40 PM UTC (b3b6a19)">Diff</a>