### PR TITLE
Editorial: Parameterize TaskSignal.any() realm and fix linking

### DIFF
--- a/spec/controlling-tasks.md
+++ b/spec/controlling-tasks.md
@@ -142,7 +142,8 @@ handler IDL attribute=] for the `onprioritychange` [=event handler=], whose [=ev
 type=] is <dfn event for=TaskSignal>prioritychange</dfn>.
 
 The static <dfn method for=TaskSignal><code>any(|signals|, |init|)</code></dfn> method steps are to
-return the result of [=creating a dependent task signal=] from |signals| and |init|.
+return the result of [=creating a dependent task signal=] from |signals|, |init|, and the
+[=current realm=].
 
 <hr>
 
@@ -153,11 +154,11 @@ To <dfn for="TaskSignal">add a priority change algorithm</dfn> |algorithm| to a 
 object |signal|, [=set/append=] |algorithm| to |signal|'s [=TaskSignal/priority change algorithms=].
 
 <div algorithm>
-  To <dfn>create a dependent task signal</dfn> from a [=list=] of {{AbortSignal}} objects |signals|
-  and a {{TaskSignalAnyInit}} |init|:
+  To <dfn>create a dependent task signal</dfn> from a [=list=] of {{AbortSignal}} objects |signals|,
+  a {{TaskSignalAnyInit}} |init|, and a |realm|:
 
   1. Let |resultSignal| be the result of <a for=AbortSignal>creating a dependent signal</a> from
-     |signals| using the {{TaskSignal}} interface and the [=current realm=].
+     |signals| using the {{TaskSignal}} interface and |realm|.
   1. Set |resultSignal|'s [=TaskSignal/dependent=] to true.
   1. If |init|["{{TaskSignalAnyInit/priority}}"] is a {{TaskPriority}}, then:
     1. Set |resultSignal|'s [=TaskSignal/priority=] to |init|["{{TaskSignalAnyInit/priority}}"].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -109,7 +109,7 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/#
 spec: requestidlecallback; urlPrefix: https://www.w3.org/TR/requestidlecallback/#;
   type: method;
     text: requestIdleCallback(); for: Window; url: dom-window-requestidlecallback
-spec: ECMASCRIPT urlPrefix: https://tc39.es/ecma262/#;
+spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/#;
   type: dfn
     text: current realm; url: current-realm
 </pre>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/85.html" title="Last updated on Apr 5, 2024, 11:53 PM UTC (8f6fafe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/85/27cd411...shaseley:8f6fafe.html" title="Last updated on Apr 5, 2024, 11:53 PM UTC (8f6fafe)">Diff</a>