### PR TITLE
Make task queue selection per agent rather than per scheduler

### DIFF
--- a/spec/patches.md
+++ b/spec/patches.md
@@ -24,25 +24,33 @@ queue=].
 With: For each [=event loop=], every [=task source=] that is not a [=scheduler task source=] must be
 associated with a specific [=task queue=].
 
+Add: An [=event loop=] has a numeric <dfn for="event loop">next enqueue order</dfn> which is
+initialized to 1.
+
+Note: The [=event loop/next enqueue order=] is a strictly increasing number that is used to
+determine task execution order across [=scheduler task queues=] of the same {{TaskPriority}} across
+all {{Scheduler}}s associated with the same [=event loop=]. A timestamp would also suffice as long
+as it is guaranteed to be strictly increasing and unique.
+
 ### <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">Event loop: processing model</a> ### {#sec-patches-html-event-loop-processing}
 
-Add the following steps to the event loop processing steps, before step 1:
+Add the following steps to the event loop processing steps, before step 2:
 
   1. Let |queues| be the [=set=] of the [=event loop=]'s [=task queues=] that contain at least one
      [=task/runnable=] [=task=].
-  1. Let |schedulers| be the [=set=] of all {{Scheduler}} objects whose [=relevant agent's=]
-     [=agent/event loop=] is this event loop and that [=have a runnable task=].
-  1. If |schedulers| and |queues| are both [=list/empty=], skip to the <code>microtasks</code> step
-     below.
+  1. Let |schedulerQueue| be the result of [=selecting the next scheduler task queue from all
+     schedulers=].
 
-Modify step 1 to read:
+Modify step 2 to read:
+
+  1. If |schedulerQueue| is not null or |queues| is not [=list/empty=]:
+
+Modify step 2.1 to read:
 
   1. Let |taskQueue| be one of the following, chosen in an [=implementation-defined=] manner:
     * If |queues| is not [=list/empty=], one of the [=task queues=] in |queues|, chosen in an
       [=implementation-defined=] manner.
-    * If |schedulers| is not [=list/empty=], the result of [=selecting the task queue of the next
-      scheduler task=] from one of the {{Scheduler}}s in |schedulers|, chosen in an
-      [=implementation-defined=] manner.
+    * |schedulerQueue|'s [=scheduler task queue/tasks=], if |schedulerQueue| is not null.
 
 Issue: The |taskQueue| in this step will either be a [=set=] of [=tasks=] or a [=set=] of
 [=scheduler tasks=]. The steps that follow only [=set/remove=] an [=set/item=], so they are


### PR DESCRIPTION
The postTask spec allows the next Scheduler task to be the oldest, highest priority task from any of its task queues, enabling per-frame task prioritization decisions. But HTML task queues are per agent/event loop, and as such other scheduling decisions typically cannot take into account a task's frame. It's not clear there's a benefit to enabling some tasks to be per frame while others are per agent, and removing this simplifies things and makes overall prioritization easier to understand, which is what this change does.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/87.html" title="Last updated on Apr 29, 2024, 9:33 PM UTC (830630f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/87/239d8c2...shaseley:830630f.html" title="Last updated on Apr 29, 2024, 9:33 PM UTC (830630f)">Diff</a>