### PR TITLE
Fix xref in 'schedule a yield continuation'

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -391,7 +391,7 @@ Issue: [=Run steps after a timeout=] doesn't necessarily account for suspension;
   1. Let |result| be [=a new promise=].
   1. Let |abortOption| be |options|["{{SchedulerYieldOptions/signal}}"] if it [=map/exists=],
      otherwise null.
-  1. Let |priorityOption| be |options|["{{SchedulerPostTaskOptions/priority}}"] if it
+  1. Let |priorityOption| be |options|["{{SchedulerYieldOptions/priority}}"] if it
      [=map/exists=], otherwise null.
   1. If |abortOption| is null and |priorityOption| is null, then set |abortOption| to
      "{{SchedulerSignalInherit/inherit}}" and set |priorityOption| to


### PR DESCRIPTION
Fixes #97.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/99.html" title="Last updated on Jul 10, 2024, 5:53 PM UTC (0fe2e6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/99/054fcc5...shaseley:0fe2e6a.html" title="Last updated on Jul 10, 2024, 5:53 PM UTC (0fe2e6a)">Diff</a>