### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -318,8 +318,9 @@ A <dfn>task handle</dfn> is a [=struct=] with the following [=struct/items=]:
        steps:
       1. Let |event loop| be the |scheduler|'s [=relevant agent=]'s [=agent/event loop=].
       1. Set |event loop|'s [=event loop/current scheduling state=] to |state|.
-      1. Let |callbackResult| be the result of [=invoking=] |callback|. If that threw an exception,
-         then [=reject=] |result| with that, otherwise resolve |result| with |callbackResult|.
+      1. Let |callbackResult| be the result of [=invoking=] |callback| with « » and "`rethrow`".
+         If that threw an exception, then [=reject=] |result| with that. Otherwise, [=resolve=]
+         |result| with |callbackResult|.
       1. Set |event loop|'s [=event loop/current scheduling state=] to null.
   1. Let |delay| be |options|["{{SchedulerPostTaskOptions/delay}}"].
   1. If |delay| is greater than 0, then [=run steps after a timeout=] given |scheduler|'s [=relevant


### PR DESCRIPTION
Part of whatwg/webidl#1425.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/scheduling-apis/pull/102.html" title="Last updated on Aug 12, 2024, 2:51 PM UTC (97cbe1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/102/4b53840...jeremyroman:97cbe1e.html" title="Last updated on Aug 12, 2024, 2:51 PM UTC (97cbe1e)">Diff</a>