### PR TITLE
Editorial: Fix bad linking due to removed ContinuationPriority

### DIFF
--- a/spec/security.md
+++ b/spec/security.md
@@ -72,11 +72,11 @@ possible for an attacker to further reduce the set of potential tasks that can
 run instead of its own by leveraging this priority. For example, if a UA uses a
 simple static prioritization scheme spanning all event loops in a thread, then
 using "{{TaskPriority/user-blocking}}" {{Scheduler/postTask()}} tasks or
-"{{ContinuationPriority/user-visible}}" and higher priority
-{{Scheduler/yield()}} continuations &mdash; which are meant to have a higher
-event loop priority &mdash; instead of {{Window/postMessage(message,
-options)|postMessage()}} tasks might decrease this set, depending on their
-relative prioritization and what runs between.
+"{{TaskPriority/user-visible}}" and higher priority {{Scheduler/yield()}}
+continuations &mdash; which are meant to have a higher event loop priority
+&mdash; instead of {{Window/postMessage(message, options)|postMessage()}} tasks
+might decrease this set, depending on their relative prioritization and what
+runs between.
 
 **What Mitigations are Possible?** <br/>
 There are mitigations that implementers can consider to minimize the risk:


### PR DESCRIPTION
I'm not sure how this made it through in the change that removed ContinuationPriority, but this removes a stale reference to ContinuationPriority.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/103.html" title="Last updated on Aug 9, 2024, 9:55 PM UTC (baa04a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/103/ab9bdc9...shaseley:baa04a6.html" title="Last updated on Aug 9, 2024, 9:55 PM UTC (baa04a6)">Diff</a>