### PR TITLE
Editorial: Remove remaining references to scheduler.yield options

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -99,7 +99,7 @@ the API into existing code that uses {{AbortSignal|AbortSignals}}.
     milliseconds.
   </dd>
 
-  <dt><code>result = scheduler . {{Scheduler/yield()|yield}}( |options| )</code></dt>
+  <dt><code>result = scheduler . {{Scheduler/yield()|yield}}()</code></dt>
   <dd>
     <p>Returns a promise that is fulfilled with <code>undefined</code> or rejected with the
     {{AbortSignal}}'s [=AbortSignal/abort reason=], if the continuation is aborted.
@@ -142,8 +142,8 @@ The <dfn method for=Scheduler title="postTask(callback, options)">postTask(|call
 method steps are to return the result of [=scheduling a postTask task=] for [=this=] given
 |callback| and |options|.
 
-The <dfn method for=Scheduler title="yield(options)">yield(|options|)</dfn> method steps are to
-return the result of [=scheduling a yield continuation=] for [=this=] given |options|.
+The <dfn method for=Scheduler title="yield()">yield()</dfn> method steps are to
+return the result of [=scheduling a yield continuation=] for [=this=].
 
 
 ## Definitions ## {#sec-scheduling-tasks-definitions}


### PR DESCRIPTION
following removal in #100, presumably these need to go too

(Incidentally, bikeshed errors for me, but I eventually found https://github.com/speced/bikeshed/issues/2621 which fixes the link error for me too. Somehow the github action is working, though? 🤷)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brendankenny/scheduling-apis/pull/105.html" title="Last updated on Aug 22, 2024, 7:53 PM UTC (426c398)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/105/714aeb3...brendankenny:426c398.html" title="Last updated on Aug 22, 2024, 7:53 PM UTC (426c398)">Diff</a>