### PR TITLE
yield: Add null check for inherited state in spec

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -342,10 +342,12 @@ Issue: [=Run steps after a timeout=] doesn't necessarily account for suspension;
   1. Let |result| be [=a new promise=].
   1. Let |inheritedState| be the |scheduler|'s [=relevant agent=]'s [=agent/event loop=]'s
      [=event loop/current scheduling state=].
-  1. Let |abortSource| be |inheritedState|'s [=scheduling state/abort source=].
+  1. Let |abortSource| be |inheritedState|'s [=scheduling state/abort source=] if |inheritedState|
+     is not null, or otherwise null.
   1. If |abortSource| is not null and |abortSource| is [=AbortSignal/aborted=], then [=reject=]
      |result| with |abortSource|'s [=AbortSignal/abort reason=] and return |result|.
-  1. Let |prioritySource| be |inheritedState|'s [=scheduling state/priority source=].
+  1. Let |prioritySource| be |inheritedState|'s [=scheduling state/priority source=] if
+     |inheritedState| is not null, or otherwise null.
   1. If |prioritySource| is null, then set |prioritySource| to the result of [=creating a fixed
      priority unabortable task signal=] given "{{TaskPriority/user-visible}}".
   1. Let |handle| be the result of [=creating a task handle=] given |result| and |abortSource|.


### PR DESCRIPTION
"schedule a yield continuation" was not taking into account that the current scheduling state can be null, in which case the priority source and abort source are null, and a non-abortable, user-visible continuation should be scheduled. The latter is handled already by the abort and priority source null checks, but these weren't being initialized to null if the inherited scheduling state is null.

Fixes #106


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/107.html" title="Last updated on Sep 16, 2024, 5:15 PM UTC (bda2446)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/107/00a8773...shaseley:bda2446.html" title="Last updated on Sep 16, 2024, 5:15 PM UTC (bda2446)">Diff</a>