### PR TITLE
Fix typo in "scheduling-tasks.md".

### DIFF
--- a/spec/scheduling-tasks.md
+++ b/spec/scheduling-tasks.md
@@ -21,7 +21,7 @@ Note that tasks scheduled with this priority will typically have a higher event 
 compared to other tasks, but they are not necessarily render-blocking. Work that needs to happen
 immediately without interruption should typically be done synchronously &mdash; but this can lead to
 poor responsiveness if the work takes too long. "{{TaskPriority/user-blocking}}" tasks, on the other
-hand, can be used to break up work and remain remain responsive to input and rendering, while
+hand, can be used to break up work and remain responsive to input and rendering, while
 increasing the liklihood that the work finishes as soon as possible.
 
 <dfn enum-value for=TaskPriority>user-visible</dfn> is the second highest priority, and it is meant


### PR DESCRIPTION
It seems to me that there is a mistake here and the word is repeated twice.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WOLFRIEND/scheduling-apis/pull/116.html" title="Last updated on Apr 1, 2025, 11:33 AM UTC (e579bf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/116/83873f3...WOLFRIEND:e579bf0.html" title="Last updated on Apr 1, 2025, 11:33 AM UTC (e579bf0)">Diff</a>